### PR TITLE
OnReceiveRealCondition() in KiwoomOpenApiPlusConditionEventHandler is not working.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ cython_debug/
 
 # Other
 /manuals
+
+# credential file
+koapy.conf

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusEventHandlers.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusEventHandlers.py
@@ -1469,7 +1469,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
     def OnReceiveRealCondition(
         self, code, condition_type, condition_name, condition_index
     ):
-        if (condition_name, condition_index) == (
+        if (condition_name, int(condition_index)) == (
             self._condition_name,
             self._condition_index,
         ):


### PR DESCRIPTION
Returning condition_index: `str` is not matching with the original request argument type `int`.

This patch fixes #2 