### PR TITLE
Bugfix/version update wrongly check if openapi logged in or not

### DIFF
--- a/koapy/backend/kiwoom_open_api_plus/core/KiwoomOpenApiPlusVersionUpdater.py
+++ b/koapy/backend/kiwoom_open_api_plus/core/KiwoomOpenApiPlusVersionUpdater.py
@@ -254,7 +254,7 @@ class KiwoomOpenApiPlusVersionUpdater(Logging):
         try:
             self.logger.info("Waiting for successful login")
             timeout_login_successful = 30
-            login_window.wait_not("visible", timeout_login_successful)
+            login_window.wait_not("exists", timeout_login_successful)
         except pywinauto.timings.TimeoutError:
             self.logger.info("Login screen is still open")
             self.logger.info("Check for possible version update")


### PR DESCRIPTION
In some situation, `pywinauto` does not detect visible state of "Open API Login" window even it is showed on screen. This can be fixed by lowering criterion `visible` to `exists` because login window definitely disappears (not exist) from the screen after it successfully finishes the login process.
