### PR TITLE
[FIXBUG] fix partial order key not found error.

### DIFF
--- a/koapy/backtrader/KiwoomOpenApiPlusStore.py
+++ b/koapy/backtrader/KiwoomOpenApiPlusStore.py
@@ -761,7 +761,6 @@ class KiwoomOpenApiPlusStore(Logging, metaclass=MetaKiwoomOpenApiPlusStore):
             return
 
         try:
-            oref = self._ordersrev[oid]
             self._process_transaction(oid, trans)
         except KeyError:  # not yet seen, keep as pending
             self._transpend[oid].append(trans)
@@ -776,7 +775,7 @@ class KiwoomOpenApiPlusStore(Logging, metaclass=MetaKiwoomOpenApiPlusStore):
 
     def _process_transaction(self, oid, trans):
         try:
-            oref = self._ordersrev.pop(oid)
+            oref = self._ordersrev[oid]
         except KeyError:
             return
 


### PR DESCRIPTION
주문의 일부가 체결될 경우 백트레이더에서는 order.PARTIAL 이 호출되게 되어있다.
하지만 kiwoom store에서 주문의 일부분이 성공하면 ordersrev에서 키를 제거함으로 이후
order.COMPLETE가 호출되지 못하는 버그를 수정합니다.

키가 제거 되지 않음으로 딕셔너리가 무한히 커지는 메모리릭이 발생할 수 있으나 백트레이더에서
다른 오더 구현도 dict에서 키를 제거하지 않고 오더의 횟수나 저장 객체가 크지 않아 허용범위라고 생각합니다.

- 사용하지 않는 라인을 삭제합니다.