### PR TITLE
[BUGFIX] order key error.

### DIFF
--- a/koapy/backtrader/KiwoomOpenApiPlusStore.py
+++ b/koapy/backtrader/KiwoomOpenApiPlusStore.py
@@ -211,10 +211,17 @@ class API:
             quote_type,
             original_order_no,
         )
-        _msg = next(responses)
-        _tr = next(responses)
-        accept = next(responses)
-        accept_data = dict(zip(accept.single_data.names, accept.single_data.values))
+
+        MAX_ORDER_RES_CNT = 5
+        for i in range(MAX_ORDER_RES_CNT):
+            res = next(responses)
+            if (
+                res.name == "OnReceiveChejanData"
+                and res.arguments[0].string_value == "0"  # 주문접수 or 체결
+            ):
+                break
+
+        accept_data = dict(zip(res.single_data.names, res.single_data.values))
         result = {"orderOpened": {"id": accept_data["주문번호"]}}
         return result
 


### PR DESCRIPTION
가끔 이벤트 수신 순서가 바뀌는 경우가 존재.
키움 명세서에도 이벤트 순서가 바뀔 수 있다고 명세 되어 있습니다.
처리 완료 chenjan 데이터를 받을 떄까지 최대 5번 확인합니다.
그 안에 키가 있다면 정상처리 그렇지 않다면 이전과 같이 에러를 발생시킵니다.