### PR TITLE
Bugfix: Proper `async_call` error/exception handling

### DIFF
--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusConditionEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusConditionEventHandler.py
@@ -60,7 +60,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
                 self._search_type,
             ),
             "Failed to send condition",
-            except_callback=lambda e: self.observer.on_error(e)
+            except_callback=self.observer.on_error
         )
 
     def OnReceiveTrCondition(
@@ -104,7 +104,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
                         self._request_name,
                         self._screen_no,
                     ),
-                    except_callback=lambda e: self.observer.on_error(e)
+                    except_callback=self.observer.on_error
                 )
 
             should_continue = str(prevnext) not in ["", "0"]
@@ -163,7 +163,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
                         self._request_name,
                         self._screen_no,
                     ),
-                    except_callback=lambda e: self.observer.on_error(e)
+                    except_callback=self.observer.on_error
                 )
 
     def OnReceiveTrData(
@@ -252,7 +252,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
                             self._request_name,
                             self._screen_no,
                         ),
-                        except_callback=lambda e: self.observer.on_error(e)
+                        except_callback=self.observer.on_error
                     )  # pylint: disable=unreachable
                 except KiwoomOpenApiPlusError as e:
                     self.observer.on_error(e)

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusConditionEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusConditionEventHandler.py
@@ -60,6 +60,7 @@ class KiwoomOpenApiPlusConditionEventHandler(
                 self._search_type,
             ),
             "Failed to send condition",
+            except_callback=lambda e: self.observer.on_error(e)
         )
 
     def OnReceiveTrCondition(
@@ -102,7 +103,8 @@ class KiwoomOpenApiPlusConditionEventHandler(
                         self._type_flag,
                         self._request_name,
                         self._screen_no,
-                    )
+                    ),
+                    except_callback=lambda e: self.observer.on_error(e)
                 )
 
             should_continue = str(prevnext) not in ["", "0"]
@@ -160,7 +162,8 @@ class KiwoomOpenApiPlusConditionEventHandler(
                         self._type_flag,
                         self._request_name,
                         self._screen_no,
-                    )
+                    ),
+                    except_callback=lambda e: self.observer.on_error(e)
                 )
 
     def OnReceiveTrData(
@@ -248,7 +251,8 @@ class KiwoomOpenApiPlusConditionEventHandler(
                             3 if self._is_future_option else 0,
                             self._request_name,
                             self._screen_no,
-                        )
+                        ),
+                        except_callback=lambda e: self.observer.on_error(e)
                     )  # pylint: disable=unreachable
                 except KiwoomOpenApiPlusError as e:
                     self.observer.on_error(e)

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusKwTrEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusKwTrEventHandler.py
@@ -99,7 +99,8 @@ class KiwoomOpenApiPlusKwTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Lo
                     self._type_flag,
                     self._rqname,
                     scrnno,
-                )
+                ),
+                except_callback=lambda e: self.observer.on_error(e)
             )
 
     def OnReceiveTrData(

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusKwTrEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusKwTrEventHandler.py
@@ -100,7 +100,7 @@ class KiwoomOpenApiPlusKwTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Lo
                     self._rqname,
                     scrnno,
                 ),
-                except_callback=lambda e: self.observer.on_error(e)
+                except_callback=self.observer.on_error
             )
 
     def OnReceiveTrData(

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusOrderEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusOrderEventHandler.py
@@ -218,7 +218,7 @@ class KiwoomOpenApiPlusOrderEventHandler(
                 self._hogagb,
                 self._orgorderno,
             ),
-            except_callback=lambda e: self.observer.on_error(e)
+            except_callback=self.observer.on_error
         )
 
     def OnReceiveMsg(self, scrnno, rqname, trcode, msg):

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusOrderEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusOrderEventHandler.py
@@ -217,7 +217,8 @@ class KiwoomOpenApiPlusOrderEventHandler(
                 self._price,
                 self._hogagb,
                 self._orgorderno,
-            )
+            ),
+            except_callback=lambda e: self.observer.on_error(e)
         )
 
     def OnReceiveMsg(self, scrnno, rqname, trcode, msg):

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusTrEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusTrEventHandler.py
@@ -74,7 +74,8 @@ class KiwoomOpenApiPlusTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Logg
         KiwoomOpenApiPlusError.try_or_raise(
             self.control.RateLimitedCommRqData.async_call(
                 self._rqname, self._trcode, 0, self._scrnno, self._inputs
-            )
+            ),
+            except_callback=lambda e: self.observer.on_error(e)
         )
 
     def OnReceiveTrData(
@@ -148,17 +149,13 @@ class KiwoomOpenApiPlusTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Logg
 
             if should_stop:
                 self.observer.on_completed()
-                return
             else:
-                try:
-                    KiwoomOpenApiPlusError.try_or_raise(
-                        self.control.RateLimitedCommRqData.async_call(
-                            rqname, trcode, int(prevnext), scrnno, self._inputs
-                        )
-                    )
-                except KiwoomOpenApiPlusError as e:
-                    self.observer.on_error(e)
-                    return
+                KiwoomOpenApiPlusError.try_or_raise(
+                    self.control.RateLimitedCommRqData.async_call(
+                        rqname, trcode, int(prevnext), scrnno, self._inputs
+                    ),
+                    except_callback=lambda e: self.observer.on_error(e)
+                )
 
     def OnEventConnect(self, errcode):
         if errcode < 0:

--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusTrEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusTrEventHandler.py
@@ -75,7 +75,7 @@ class KiwoomOpenApiPlusTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Logg
             self.control.RateLimitedCommRqData.async_call(
                 self._rqname, self._trcode, 0, self._scrnno, self._inputs
             ),
-            except_callback=lambda e: self.observer.on_error(e)
+            except_callback=self.observer.on_error
         )
 
     def OnReceiveTrData(
@@ -154,7 +154,7 @@ class KiwoomOpenApiPlusTrEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Logg
                     self.control.RateLimitedCommRqData.async_call(
                         rqname, trcode, int(prevnext), scrnno, self._inputs
                     ),
-                    except_callback=lambda e: self.observer.on_error(e)
+                    except_callback=self.observer.on_error
                 )
 
     def OnEventConnect(self, errcode):


### PR DESCRIPTION
QRateLimitedExecutor wrapping functions like `RateLimitedCommRqData`, `RateLimitedCommKwRqData`, `RateLimitedSendOrder`, `RateLimitedSendCondition` return `concurrent.futures.Future` object immediately upon asynchronous execution with `async_call`.

Therefore, the result after execution should be returned by attaching [callback functions 1](https://github.com/elbakramer/koapy/blob/69ca07a62590acebddd0ccf9d3eaecf37fa1b8a2/koapy/backend/kiwoom_open_api_plus/core/KiwoomOpenApiPlusError.py#L210-L215), [2](https://github.com/elbakramer/koapy/blob/69ca07a62590acebddd0ccf9d3eaecf37fa1b8a2/koapy/backend/kiwoom_open_api_plus/core/KiwoomOpenApiPlusError.py#L281-L286) to the Future object. However, the callback implementation contained in `try_or_raise` currently does not have a way to properly handle an error or an exception in the function return.

For example, if an error or exception occurs between immediately after the execution of a function and before the event begins to return, there is no way on the server side to notify the client that there is an error, and the client will continue to wait for the next message. I found this [attempt](https://github.com/elbakramer/koapy/blob/69ca07a62590acebddd0ccf9d3eaecf37fa1b8a2/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusTrEventHandler.py#L153-L161), but this is an invalid exception handling method for `async_call` returning a Future object.

In this pull request, the `except_callback` argument to receive the exception object when an error or exception occurs was added to `try_or_raise`, and I tried to find a place where it can be used and apply it all.