### PR TITLE
Future.result(timeout=None) blocks the thread.

### DIFF
--- a/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusRealEventHandler.py
+++ b/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusRealEventHandler.py
@@ -74,7 +74,7 @@ class KiwoomOpenApiPlusRealEventHandler(KiwoomOpenApiPlusEventHandlerForGrpc, Lo
                     code_list_joined,
                     self._fid_list_joined,
                     self._opt_type_final,
-                ).result()
+                )
             )
 
     def OnReceiveRealData(self, code, realtype, realdata):


### PR DESCRIPTION
It makes `async` to `sync` call. Caller thread `await`s the `Future` instance.
Because a thread processing `OnReceiveRealData()` is also possibly the thread processing `on_enter()`, it might form acyclic deadlock.

If you need handling exceptions, please see the snippet that I wrote:
https://github.com/elbakramer/koapy/blob/b4cc36bc997daf90f117c3d908c8b7b9fd3a9b22/koapy/backend/kiwoom_open_api_plus/grpc/event/KiwoomOpenApiPlusRealEventHandler.py#L181-L215