### PR TITLE
Bugfix: auto-login

### DIFF
--- a/koapy/cli/utils/credentials.py
+++ b/koapy/cli/utils/credentials.py
@@ -43,17 +43,20 @@ def prompt_credentials():
             default=default_cert_password,
             show_default=False,
         )
-    account_count = click.prompt("Account Count", type=int, default=1)
+        
     account_passwords = {}
-    for _ in range(account_count):
-        account_number = click.prompt("Account Number", default="0000000000")
-        account_password = click.prompt(
-            "Account Password",
-            hide_input=True,
-            default="0000",
-            show_default=False,
-        )
-        account_passwords[account_number] = account_password
+    if is_simulation:
+        account_passwords['0000000000'] = '0000'
+    else:
+        account_count = click.prompt("Account Count", type=int, default=1)
+        for _ in range(account_count):
+            account_number = click.prompt("Account Number", default="0000000000")
+            account_password = click.prompt(
+                "Account Password",
+                hide_input=True,
+                show_default=False,
+            )
+            account_passwords[account_number] = account_password
 
     credentials = {
         "user_id": user_id,

--- a/koapy/config.conf
+++ b/koapy/config.conf
@@ -38,9 +38,7 @@
         user_password = ""
         cert_password = ""
         is_simulation = true
-        account_passwords {
-            0000000000 = "0000"
-        }
+        account_passwords {}
     }
     koapy.backend.daishin_cybos_plus.credentials {
         user_id = ""
@@ -49,9 +47,7 @@
         auto_account_password = true
         auto_cert_password = true
         price_check_only = true
-        account_passwords {
-            000000000 = "0000"
-        }
+        account_passwords {}
     }
     koapy.utils.logging.config {
         version = 1


### PR DESCRIPTION
1. simulation server checkbox cannot be set with `pywinauto`'s mouse click emulation.
2. In case of trying to set account passwords partially, KOAPY try to set password with global password (0000) for the others anyway, auto-login failed to set because of errors (account password does not match).